### PR TITLE
Fix app name

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">CTemplarApp</string>
+    <string name="app_name" translatable="false">CTemplar</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="nav_header_title">Android Studio</string>


### PR DESCRIPTION
...as this is Android... everything is an "App" no need to reinforce it. Also, keep name the same for any locale, for easy discovery.