### PR TITLE
Modifys `EMAIL_LIST` regex, to allow `=` #240

### DIFF
--- a/app/src/main/java/mobileapp/ctemplar/com/ctemplarapp/utils/EditTextUtils.java
+++ b/app/src/main/java/mobileapp/ctemplar/com/ctemplarapp/utils/EditTextUtils.java
@@ -22,7 +22,7 @@ public class EditTextUtils {
     private static final Pattern EMAIL_LIST
             = Pattern.compile(
             "(([, ]?)+" +
-            "[a-zA-Z0-9+._%\\-+]{1,256}" +
+            "[a-zA-Z0-9+._%\\-+=]{1,256}" +
             "@[a-zA-Z0-9][a-zA-Z0-9\\-]{0,64}" +
             "(" +
                 "\\." +


### PR DESCRIPTION
This is a fix for #240 

Context: When sending a message, or adding a contact where the email contains an `=` in the first part, an error message is displayed saying `"Enter Valid Email Address"`. It is valid to include such a character in an email address, and this is commonly used in mail forwarding services, such as [AnonAddy - to send a message from an alias](https://anonaddy.com/help/sending-email-from-an-alias/). It is frustrating to not be able to proceed in sending such an email at all.